### PR TITLE
feat: lite mode for PRs

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -22,6 +22,7 @@ jobs:
         name: [ backend, database, frontend ]
         include:
           - name: backend
+            dev_mode: true
             file: templates/backend.yml
             overwrite: true
             verification_path: /api
@@ -39,6 +40,7 @@ jobs:
       - id: deploys
         uses: ./
         with:
+          dev_mode: ${{ matrix.dev_mode }}
           file: ${{ matrix.file }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -22,8 +22,8 @@ jobs:
         name: [ backend, database, frontend ]
         include:
           - name: backend
-            dev_mode: true
             file: templates/backend.yml
+            lite_mode: true
             overwrite: true
             verification_path: /api
           - name: database
@@ -40,8 +40,8 @@ jobs:
       - id: deploys
         uses: ./
         with:
-          dev_mode: ${{ matrix.dev_mode }}
           file: ${{ matrix.file }}
+          lite_mode: ${{ matrix.lite_mode }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -23,7 +23,6 @@ jobs:
         include:
           - name: backend
             file: templates/backend.yml
-            lite_mode: true
             overwrite: true
             verification_path: /api
           - name: database
@@ -41,7 +40,6 @@ jobs:
         uses: ./
         with:
           file: ${{ matrix.file }}
-          lite_mode: ${{ matrix.lite_mode }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Misc
+.codebuddy/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Testing has only been done with public containers on ghcr.io (GitHub Container R
     # Development mode; useful for pull requests (PRs) and other lighter-resourced environments.
     # Skips prod-typical objects (HorizontalPodAutoscaler, PodDisruptionBudget) 
     # and limits deployment replicas to 1
-    dev_mode: "false"
+    lite_mode: "false"
     
     # Overwrite objects using `oc apply` or only create with `oc create`
     # Expected errors from `oc create` are handled with `set +o pipefail`
@@ -102,7 +102,7 @@ deploys:
     - name: Deploys
       uses: bcgov/action-deployer-openshift.yml@X.Y.Z
       with:
-        dev_mode: true
+        lite_mode: true
         file: frontend/openshift.deploy.yml
         oc_namespace: ${{ vars.OC_NAMESPACE }}
         oc_server: ${{ vars.OC_SERVER }}
@@ -217,20 +217,19 @@ deploys:
         verification_url: health
 ```
 
-# Dev Mode
+# Lite Mode
 
-Development mode is for lighter-resourced environments, like pull requests (PRs).
+Lite mode is for pull request (PR) and other resource-limited environments.  This is an alternative to setting min and max replicas to 1, which can generate errors.
 
 Object-types filtered out:
 - HorizontalPodAutoscaler
 - PodDisruptionBudget
 
-
 Deployment replicas:
 - Limited to 1.
 
 ```yaml
-dev_mode: "true"
+lite_mode: "true"
 ```
 
 # Route Verification

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ steps:
 
 # Example, Matrix / Post Rollout
 
-Deploy and run a command (post hook).  Matrix values reference `post_rollout`, `overwrite` and `triggers`, despite not being present for all deployments.  This is acceptable, but unintuitive behaviour.
+Deploy and run a command (post hook).  When values for `post_rollout`, `overwrite` and `triggers` are not provided defaults will be used.  This is convenient, but unintuitive.
 
 ```yaml
 deploys:
@@ -253,4 +253,4 @@ Please contribute your ideas!  [Issues] and [pull requests] are appreciated.
 
 <!-- # Acknowledgements
 
-This Action is provided courtesty of the Forestry Digital Services, part of the Government of British Columbia. -->
+This Action is provided courtesy of the Forestry Digital Services, part of the Government of British Columbia. -->

--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ deploys:
         verification_url: health
 ```
 
-# Lite Mode
+# Lite Mode for Pull Requests
 
-Lite mode will automatically be enabled for all pull request (PR) deployments.  This is ideal for resource-limited environments.  Please note that some alternatives, like setting min and max replicas to 1, tend to generate errors.
+Pull request (PR) deployments will automatically use lite mode.  This is ideal for resource-limited environments.
 
-Object-types filtered out:
+Object types removed:
 - HorizontalPodAutoscaler
 - PodDisruptionBudget
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ Testing has only been done with public containers on ghcr.io (GitHub Container R
 
     ### Typical / recommended
     
-    # Development mode; useful for pull requests (PRs) and other lighter-resourced environments.
-    # Skips prod-typical objects (HorizontalPodAutoscaler, PodDisruptionBudget) 
-    # and limits deployment replicas to 1
-    lite_mode: "false"
-    
     # Overwrite objects using `oc apply` or only create with `oc create`
     # Expected errors from `oc create` are handled with `set +o pipefail`
     overwrite: "true"
@@ -92,7 +87,7 @@ Testing has only been done with public containers on ghcr.io (GitHub Container R
 
 # Example, Single Template
 
-Deploy a single template.  Multiple GitHub secrets are used.  Dev mode enabled.
+Deploy a single template.  Multiple GitHub secrets are used.
 
 ```yaml
 deploys:
@@ -102,7 +97,6 @@ deploys:
     - name: Deploys
       uses: bcgov/action-deployer-openshift.yml@X.Y.Z
       with:
-        lite_mode: true
         file: frontend/openshift.deploy.yml
         oc_namespace: ${{ vars.OC_NAMESPACE }}
         oc_server: ${{ vars.OC_SERVER }}
@@ -219,18 +213,15 @@ deploys:
 
 # Lite Mode
 
-Lite mode is for pull request (PR) and other resource-limited environments.  This is an alternative to setting min and max replicas to 1, which can generate errors.
+Lite mode will automatically be enabled for all pull request (PR) deployments.  This is ideal for resource-limited environments.  Please note that some alternatives, like setting min and max replicas to 1, tend to generate errors.
 
 Object-types filtered out:
 - HorizontalPodAutoscaler
 - PodDisruptionBudget
 
-Deployment replicas:
-- Limited to 1
-
-```yaml
-lite_mode: "true"
-```
+Deployment modifications:
+- Replicas limited to 1 (deployment.spec.replicas)
+- Rollout strategy limited to `Recreate` (deployment.spec.strategy.type)
 
 # Route Verification
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Testing has only been done with public containers on ghcr.io (GitHub Container R
 # Usage
 
 ```yaml
-- uses: bcgov/action-deployer-openshift@main
+- uses: bcgov/action-deployer-openshift@X.Y.Z
   with:
     ### Required
 
@@ -100,7 +100,7 @@ deploys:
   runs-on: ubuntu-24.04
   steps:
     - name: Deploys
-      uses: bcgov/action-deployer-openshift.yml@main
+      uses: bcgov/action-deployer-openshift.yml@X.Y.Z
       with:
         dev_mode: true
         file: frontend/openshift.deploy.yml
@@ -144,7 +144,7 @@ runs-on: ubuntu-24.04
         file: common/openshift.init.yml
 steps:
   - name: Deploys
-    uses: bcgov/action-deployer-openshift.yml@main
+    uses: bcgov/action-deployer-openshift.yml@X.Y.Z
     with:
       name: ${{ matrix.name }}
       file: ${{ matrix.file }}
@@ -180,7 +180,7 @@ runs-on: ubuntu-24.04
         triggers: ('backend/', 'frontend/')
 steps:
   - name: Deploys
-    uses: bcgov/action-deployer-openshift.yml@main
+    uses: bcgov/action-deployer-openshift.yml@X.Y.Z
     with:
       name: ${{ matrix.name }}
       file: ${{ matrix.file }}
@@ -203,7 +203,7 @@ deploys:
   runs-on: ubuntu-24.04
   steps:
     - name: Deploys
-      uses: bcgov/action-deployer-openshift.yml@main
+      uses: bcgov/action-deployer-openshift.yml@X.Y.Z
       with:
         file: backend/openshift.deploy.yml
         oc_namespace: ${{ vars.OC_NAMESPACE }}

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Object-types filtered out:
 - PodDisruptionBudget
 
 Deployment replicas:
-- Limited to 1.
+- Limited to 1
 
 ```yaml
 lite_mode: "true"

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,6 @@ inputs:
     required: true
 
   ### Typical / recommended
-  lite_mode:
-    description: Lite mode; skips prod-typical objects and limits deployment replicas to 1 (true|false)
-    default: false
   overwrite:
     description: Replace existing objects/artifacts? (true|false)
     required: true
@@ -121,7 +118,7 @@ runs:
           # Apply (overwrites) or create (does not overwrite) using processed template
           TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
 
-          if [ "${{ inputs.lite_mode }}" == "true" ]; then
+          if [ "${{ github.event_name == 'pull_request' }}" ]; then
             echo -e "\nDevelopment mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
@@ -143,13 +140,13 @@ runs:
           fi
 
           # Deployment and Route Host from template (note: DeploymentConfig is deprecated, but still supported)
-          DCC=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").metadata.name //empty')
+          DEPLOYMENT=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").metadata.name //empty')
 
           # Follow any active rollouts; temporary support for DeploymentConfigs
-          if [ ! -z "${DDC}" ]&&[ ! -z $(oc get deployment ${DDC} -o name --ignore-not-found) ]; then
-            oc rollout status deployment/${DDC} -w
-          elif [ ! -z "${DDC}" ]&&[ ! -z $(oc get deploymentconfig ${DDC} -o name --ignore-not-found) ]; then
-            oc rollout status deploymentconfig/${DDC} -w
+          if [ ! -z "${DEPLOYMENT}" ]&&[ ! -z $(oc get deployment ${DEPLOYMENT} -o name --ignore-not-found) ]; then
+            oc rollout status deployment/${DEPLOYMENT} -w
+          elif [ ! -z "${DEPLOYMENT}" ]&&[ ! -z $(oc get deploymentconfig ${DEPLOYMENT} -o name --ignore-not-found) ]; then
+            oc rollout status deploymentconfig/${DEPLOYMENT} -w
           fi
 
     - uses: bcgov/action-oc-runner@v1.0.0

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
           fi
 
           # Deployment and Route Host from template (note: DeploymentConfig is deprecated, but still supported)
-          DDC="$(jq -rn "${TEMPLATE} | .items[] | select([.kind] | inside([\"Deployment\", \"DeploymentConfig\"])).metadata.name //empty")"
+          DCC=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").metadata.name //empty')
 
           # Follow any active rollouts; temporary support for DeploymentConfigs
           if [ ! -z "${DDC}" ]&&[ ! -z $(oc get deployment ${DDC} -o name --ignore-not-found) ]; then

--- a/action.yml
+++ b/action.yml
@@ -113,20 +113,18 @@ runs:
         commands: |
           # Expand for deployment steps
 
-          set -x
-
           # Apply (overwrites) or create (does not overwrite) using processed template
           TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
 
           if [ "${{ github.event_name == 'pull_request' }}" ]; then
-            echo -e "\nDevelopment mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
+            echo -e "\nLite mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
 
-            echo -e "\nDevelopment mode; limiting deployment replicas to 1"
+            echo -e "\nLite mode; limiting deployment replicas to 1"
             TEMPLATE=$(echo "${TEMPLATE}" | jq '.items |= map(if .kind == "Deployment" then .spec.replicas = 1 else . end)')
 
-            echo -e "\nDevelopment mode; limiting deployment strategy to Recreate"
+            echo -e "\nLite mode; limiting deployment strategy to Recreate"
             TEMPLATE=$(echo "${TEMPLATE}" | jq '.items |= map(if .kind == "Deployment" then .spec.strategy.type = "Recreate" else . end)')
           fi
           

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
 
             echo -e "\nDevelopment mode; limiting deployment replicas to 1"
-            TEMPLATE=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").spec.replicas=1')
+            TEMPLATE=$(echo "${TEMPLATE}" | jq '.items |= map(if .kind == "Deployment" then .spec.replicas = 1 else . end)')
           fi
           
           if [ "${{ inputs.overwrite }}" != "false" ]; then

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,8 @@ runs:
         commands: |
           # Expand for deployment steps
 
+          set -x
+
           # Apply (overwrites) or create (does not overwrite) using processed template
           TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
 
@@ -124,7 +126,7 @@ runs:
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
 
-            echo -e "\Development mode; limiting deployment replicas to 1"
+            echo -e "\nDevelopment mode; limiting deployment replicas to 1"
             TEMPLATE=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").spec.replicas=1')
           fi
           

--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,7 @@ inputs:
 
   ### Typical / recommended
   dev_mode:
-    description: Development mode; skips prod-typical objects (HorizontalPodAutoscaler, PodDisruptionBudget)
-    default: false
-  limit_replicas:
-    description: Limit deployment replicas to 1 (true|false)
+    description: Development mode; skips prod-typical objects and limits deployment replicas to 1 (true|false)
     default: false
   overwrite:
     description: Replace existing objects/artifacts? (true|false)
@@ -123,13 +120,11 @@ runs:
           TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
 
           if [ "${{ inputs.dev_mode }}" == "true" ]; then
-            echo "Development mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
+            echo -e "\nDevelopment mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
-          fi
 
-          if [ "${{ inputs.limit_replicas }}" == "true" ]; then
-            echo "Limiting deployment replicas to 1"
+            echo -e "\Development mode; limiting deployment replicas to 1"
             TEMPLATE=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").spec.replicas=1')
           fi
           

--- a/action.yml
+++ b/action.yml
@@ -128,6 +128,9 @@ runs:
 
             echo -e "\nDevelopment mode; limiting deployment replicas to 1"
             TEMPLATE=$(echo "${TEMPLATE}" | jq '.items |= map(if .kind == "Deployment" then .spec.replicas = 1 else . end)')
+
+            echo -e "\nDevelopment mode; limiting deployment strategy to Recreate"
+            TEMPLATE=$(echo "${TEMPLATE}" | jq '.items |= map(if .kind == "Deployment" then .spec.strategy.type = "Recreate" else . end)')
           fi
           
           if [ "${{ inputs.overwrite }}" != "false" ]; then

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   dev_mode:
     description: Development mode; skips prod-typical objects (HorizontalPodAutoscaler, PodDisruptionBudget)
     default: false
+  limit_replicas:
+    description: Limit deployment replicas to 1 (true|false)
+    default: false
   overwrite:
     description: Replace existing objects/artifacts? (true|false)
     required: true
@@ -123,6 +126,11 @@ runs:
             echo "Development mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
+          fi
+
+          if [ "${{ inputs.limit_replicas }}" == "true" ]; then
+            echo "Limiting deployment replicas to 1"
+            TEMPLATE=$(echo "${TEMPLATE}" | jq '.items[] | select(.kind=="Deployment").spec.replicas=1')
           fi
           
           if [ "${{ inputs.overwrite }}" != "false" ]; then

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     required: true
 
   ### Typical / recommended
+  dev_mode:
+    description: Development mode; skips prod-typical objects (HorizontalPodAutoscaler, PodDisruptionBudget)
+    default: false
   overwrite:
     description: Replace existing objects/artifacts? (true|false)
     required: true
@@ -115,6 +118,13 @@ runs:
 
           # Apply (overwrites) or create (does not overwrite) using processed template
           TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
+
+          if [ "${{ inputs.dev_mode }}" == "true" ]; then
+            echo "Development mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
+            TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
+            TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')
+          fi
+          
           if [ "${{ inputs.overwrite }}" != "false" ]; then
             echo "Overwrite=true; using oc apply"
             oc apply --timeout=${{ inputs.timeout || '15m' }} -f - <<< "${TEMPLATE}"

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
     required: true
 
   ### Typical / recommended
-  dev_mode:
-    description: Development mode; skips prod-typical objects and limits deployment replicas to 1 (true|false)
+  lite_mode:
+    description: Lite mode; skips prod-typical objects and limits deployment replicas to 1 (true|false)
     default: false
   overwrite:
     description: Replace existing objects/artifacts? (true|false)
@@ -119,7 +119,7 @@ runs:
           # Apply (overwrites) or create (does not overwrite) using processed template
           TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
 
-          if [ "${{ inputs.dev_mode }}" == "true" ]; then
+          if [ "${{ inputs.lite_mode }}" == "true" ]; then
             echo -e "\nDevelopment mode; skipping HorizontalPodAutoscaler and PodDisruptionBudget objects"
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="HorizontalPodAutoscaler"))')
             TEMPLATE=$(echo "${TEMPLATE}" | jq 'del(.items[] | select(.kind=="PodDisruptionBudget"))')


### PR DESCRIPTION
Lite mode is for pull request (PR) and other resource-limited environments.  This is an alternative to setting min and max replicas to 1, which can generate errors.

Object-types filtered out:
- HorizontalPodAutoscaler
- PodDisruptionBudget

Deployment replicas:
- Limited to 1